### PR TITLE
fix regex.

### DIFF
--- a/OmniSharp/Build/BuildLogParser.cs
+++ b/OmniSharp/Build/BuildLogParser.cs
@@ -24,7 +24,7 @@ namespace OmniSharp.Build
                 return quickFix;
             }
 
-            match = GetMatches(line, @"\s+(.*cs)\((\d+),(\d+)\).*error CS\d+: (.*) \[");
+            match = GetMatches(line, @"\s*(.*cs)\((\d+),(\d+)\).*error CS\d+: (.*) \[");
             if(match.Matched)
             {
                 var matches = match.Matches;


### PR DESCRIPTION
Hi.

In my Windows, I can't get a result of `OmniSharpBuild`. 
I think that it is because Japanese csc.exe is probably the cause.

**Example**

> c:\Users\rbtnn\Hoge\a.cs(161,17): error CS1501: 引数を 2 個指定できる、メソッド 'TooFewColumnsError' のオーバーロードはありません [C:\Users\rbtnn\Hoge\A.csproj]
