### PR TITLE
Add feature: autocomplete optional documentation

### DIFF
--- a/OmniSharp/AutoComplete/AutoCompleteHandler.cs
+++ b/OmniSharp/AutoComplete/AutoCompleteHandler.cs
@@ -34,7 +34,9 @@ namespace OmniSharp.AutoComplete
             var engine = new CSharpCompletionEngine
                 ( completionContext.Document
                 , contextProvider
-                , new CompletionDataFactory(partialWord)
+                , new CompletionDataFactory
+                  ( partialWord
+                  , request.WantDocumentationForEveryCompletionResult)
                 , completionContext.ParsedContent.ProjectContent
                 , completionContext.ResolveContext)
                 {

--- a/OmniSharp/AutoComplete/AutoCompleteRequest.cs
+++ b/OmniSharp/AutoComplete/AutoCompleteRequest.cs
@@ -13,5 +13,17 @@ namespace OmniSharp.AutoComplete
                 _wordToComplete = value;
             }
         }
+        private bool _wantDocumentationForEveryCompletionResult = true;
+
+        /// <summary>
+        ///   Specifies whether to return the code documentation for
+        ///   each and every returned autocomplete result. Defaults to
+        ///   true. Can be turned off to get a small speed boost.
+        /// </summary>
+        public bool WantDocumentationForEveryCompletionResult {
+            get { return _wantDocumentationForEveryCompletionResult; }
+            set { _wantDocumentationForEveryCompletionResult = value; }
+        }
+
     }
 }

--- a/OmniSharp/AutoComplete/CompletionDataFactory.cs
+++ b/OmniSharp/AutoComplete/CompletionDataFactory.cs
@@ -22,10 +22,12 @@ namespace OmniSharp.AutoComplete
 
         private string _completionText;
         private string _signature;
+        private bool   _wantDocumentation;
 
-        public CompletionDataFactory(string partialWord)
+        public CompletionDataFactory(string partialWord, bool wantDocumentation)
         {
             _partialWord = partialWord;
+            _wantDocumentation = wantDocumentation;
         }
 
         public ICompletionData CreateEntityCompletionData(IEntity entity)
@@ -82,7 +84,7 @@ namespace OmniSharp.AutoComplete
                 };
 
                 var documentationSignature = ambience.ConvertEntity(entity);
-                if (docProvider != null)
+                if (docProvider != null && _wantDocumentation)
                 {
                     DocumentationComment documentationComment = docProvider.GetDocumentation(entity);
                     if (documentationComment != null)


### PR DESCRIPTION
Here's a small patch that allows the user to speed up getting
AutoComplete results by turning off fetching documentation for them.

Rationale: optimisation. Getting a long list of matches is more
responsive when documentation is not returned

The default option is that documentation is fetched like it used to
be. The option may be left out, so no client code should break.
