### PR TITLE
Use references from CSharpProject in XML Doc Provider instead of custom logic

### DIFF
--- a/OmniSharp.Tests/AutoComplete/CompletionsSpecBase.cs
+++ b/OmniSharp.Tests/AutoComplete/CompletionsSpecBase.cs
@@ -30,7 +30,7 @@ namespace OmniSharp.Tests.AutoComplete
             var project = new FakeProject();
             project.AddFile(editorText);
             _solution.Projects.Add(project);
-            var provider = new AutoCompleteHandler(new BufferParser(_solution), new Logger());
+            var provider = new AutoCompleteHandler(_solution, new BufferParser(_solution), new Logger());
             var request = new AutoCompleteRequest
                 {
                     FileName = "myfile",

--- a/OmniSharp/AutoComplete/AutoCompleteHandler.cs
+++ b/OmniSharp/AutoComplete/AutoCompleteHandler.cs
@@ -4,16 +4,19 @@ using System.Linq;
 using ICSharpCode.NRefactory.CSharp.Completion;
 using ICSharpCode.NRefactory.Completion;
 using OmniSharp.Parser;
+using OmniSharp.Solution;
 
 namespace OmniSharp.AutoComplete
 {
     public class AutoCompleteHandler
     {
+        private readonly ISolution _solution;
         private readonly BufferParser _parser;
         private readonly Logger _logger;
 
-        public AutoCompleteHandler(BufferParser parser, Logger logger)
+        public AutoCompleteHandler(ISolution solution, BufferParser parser, Logger logger)
         {
+            _solution = solution;
             _parser = parser;
             _logger = logger;
         }
@@ -26,13 +29,16 @@ namespace OmniSharp.AutoComplete
 
             var partialWord = request.WordToComplete;
 
+            var project = _solution.ProjectContainingFile(request.FileName);
+
             ICompletionContextProvider contextProvider = new DefaultCompletionContextProvider
                 (completionContext.Document, completionContext.ParsedContent.UnresolvedFile);
             var engine = new CSharpCompletionEngine
                 ( completionContext.Document
                 , contextProvider
                 , new CompletionDataFactory
-                  ( partialWord
+                  ( project
+                  , partialWord
                   , request.WantDocumentationForEveryCompletionResult)
                 , completionContext.ParsedContent.ProjectContent
                 , completionContext.ResolveContext)

--- a/OmniSharp/AutoComplete/CompletionDataFactory.cs
+++ b/OmniSharp/AutoComplete/CompletionDataFactory.cs
@@ -7,6 +7,7 @@ using ICSharpCode.NRefactory.CSharp.Completion;
 using ICSharpCode.NRefactory.Completion;
 using ICSharpCode.NRefactory.Documentation;
 using ICSharpCode.NRefactory.TypeSystem;
+using OmniSharp.Solution;
 
 namespace OmniSharp.AutoComplete
 {
@@ -23,9 +24,11 @@ namespace OmniSharp.AutoComplete
         private string _completionText;
         private string _signature;
         private bool   _wantDocumentation;
+        private IProject _project;
 
-        public CompletionDataFactory(string partialWord, bool wantDocumentation)
+        public CompletionDataFactory(IProject project, string partialWord, bool wantDocumentation)
         {
+            _project = project;
             _partialWord = partialWord;
             _wantDocumentation = wantDocumentation;
         }
@@ -72,7 +75,7 @@ namespace OmniSharp.AutoComplete
                 if (entity.ParentAssembly.AssemblyName != null)
                 {
                     docProvider =
-                        XmlDocumentationProviderFactory.Get(entity.ParentAssembly.AssemblyName);
+                        XmlDocumentationProviderFactory.Get(_project, entity.ParentAssembly.AssemblyName);
                 }
                 var ambience = new CSharpAmbience
                 {


### PR DESCRIPTION
Propagate project to xml doc provider so we don't have to reimplement the reference file location logic (badly).
