### PR TITLE
Support references in the GAC

### DIFF
--- a/OmniSharp/OmniSharp.csproj
+++ b/OmniSharp/OmniSharp.csproj
@@ -186,6 +186,8 @@
     <Compile Include="Rename\RenameModule.cs" />
     <Compile Include="Rename\RenameRequest.cs" />
     <Compile Include="Rename\RenameResponse.cs" />
+    <Compile Include="Solution\Fusion.cs" />
+    <Compile Include="Solution\GacInterop.cs" />
     <Compile Include="Solution\OrphanProject.cs" />
     <Compile Include="Solution\StringExtensions.cs" />
     <Compile Include="StopServer\StopServerModule.cs" />

--- a/OmniSharp/Solution/CSharpProject.cs
+++ b/OmniSharp/Solution/CSharpProject.cs
@@ -21,10 +21,12 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using ICSharpCode.NRefactory.CSharp;
 using ICSharpCode.NRefactory.TypeSystem;
 using ICSharpCode.NRefactory.Utils;
+using Mono.Cecil;
 
 namespace OmniSharp.Solution
 {
@@ -137,6 +139,10 @@ namespace OmniSharp.Solution
                 if (assemblyFileName == null)
                     assemblyFileName = FindAssembly(AssemblySearchPaths, item.EvaluatedInclude);
 
+                //If it isn't in the search paths, try the GAC
+                if (assemblyFileName == null)
+                    assemblyFileName = FindAssemblyInNetGac(item.EvaluatedInclude);
+
                 if (assemblyFileName != null)
                 {
                     if (Path.GetFileName(assemblyFileName).Equals("System.Core.dll", StringComparison.OrdinalIgnoreCase))
@@ -225,6 +231,12 @@ namespace OmniSharp.Solution
                     return assemblyFile;
             }
             return null;
+        }
+
+        public static string FindAssemblyInNetGac(string evaluatedInclude)
+        {
+            AssemblyNameReference assemblyNameReference = AssemblyNameReference.Parse(evaluatedInclude);
+            return GacInterop.FindAssemblyInNetGac(assemblyNameReference);
         }
 
 

--- a/OmniSharp/Solution/Fusion.cs
+++ b/OmniSharp/Solution/Fusion.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) 2011 AlphaSierraPapa for the SharpDevelop Team
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+using System.Text;
+
+namespace OmniSharp.Solution
+{
+    // .NET Fusion COM interfaces
+    [ComImport(), Guid("CD193BC0-B4BC-11D2-9833-00C04FC31D2E"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IAssemblyName
+    {
+        [PreserveSig()]
+        int SetProperty(uint PropertyId, IntPtr pvProperty, uint cbProperty);
+        
+        [PreserveSig()]
+        int GetProperty(uint PropertyId, IntPtr pvProperty, ref uint pcbProperty);
+        
+        [PreserveSig()]
+        int Finalize();
+        
+        [PreserveSig()]
+        int GetDisplayName([Out(), MarshalAs(UnmanagedType.LPWStr)] StringBuilder szDisplayName,
+                           ref uint pccDisplayName,
+                           uint dwDisplayFlags);
+        
+        [PreserveSig()]
+        int BindToObject(object refIID,
+                         object pAsmBindSink,
+                         IApplicationContext pApplicationContext,
+                         [MarshalAs(UnmanagedType.LPWStr)] string szCodeBase,
+                         long llFlags,
+                         int pvReserved,
+                         uint cbReserved,
+                         out int ppv);
+        
+        [PreserveSig()]
+        int GetName(ref uint lpcwBuffer,
+                    [Out(), MarshalAs(UnmanagedType.LPWStr)] StringBuilder pwzName);
+        
+        [PreserveSig()]
+        int GetVersion(out uint pdwVersionHi, out uint pdwVersionLow);
+        
+        [PreserveSig()]
+        int IsEqual(IAssemblyName pName,
+                    uint dwCmpFlags);
+        
+        [PreserveSig()]
+        int Clone(out IAssemblyName pName);
+    }
+    
+    [ComImport(), Guid("7C23FF90-33AF-11D3-95DA-00A024A85B51"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IApplicationContext
+    {
+        void SetContextNameObject(IAssemblyName pName);
+        
+        void GetContextNameObject(out IAssemblyName ppName);
+        
+        void Set([MarshalAs(UnmanagedType.LPWStr)] string szName,
+                 int pvValue,
+                 uint cbValue,
+                 uint dwFlags);
+        
+        void Get([MarshalAs(UnmanagedType.LPWStr)] string szName,
+                 out int pvValue,
+                 ref uint pcbValue,
+                 uint dwFlags);
+        
+        void GetDynamicDirectory(out int wzDynamicDir,
+                                 ref uint pdwSize);
+    }
+    
+    [ComImport(), Guid("21B8916C-F28E-11D2-A473-00C04F8EF448"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IAssemblyEnum
+    {
+        [PreserveSig()]
+        int GetNextAssembly(out IApplicationContext ppAppCtx,
+                            out IAssemblyName ppName,
+                            uint dwFlags);
+        
+        [PreserveSig()]
+        int Reset();
+        
+        [PreserveSig()]
+        int Clone(out IAssemblyEnum ppEnum);
+    }
+    
+    internal static class Fusion
+    {
+        // dwFlags: 1 = Enumerate native image (NGEN) assemblies
+        //          2 = Enumerate GAC assemblies
+        //          4 = Enumerate Downloaded assemblies
+        //
+        [DllImport("fusion.dll", CharSet=CharSet.Auto)]
+        internal static extern int CreateAssemblyEnum(out IAssemblyEnum ppEnum,
+                                                      IApplicationContext pAppCtx,
+                                                      IAssemblyName pName,
+                                                      uint dwFlags,
+                                                      int pvReserved);
+        
+        [DllImport("fusion.dll")]
+        internal static extern int GetCachePath(uint flags,
+                                                [MarshalAs(UnmanagedType.LPWStr)] StringBuilder wzDir,
+                                                ref uint pdwSize);
+        
+        public static string GetGacPath(bool isCLRv4 = false)
+        {
+            const uint ASM_CACHE_ROOT    = 0x08; // CLR V2.0
+            const uint ASM_CACHE_ROOT_EX = 0x80; // CLR V4.0
+            uint flags = isCLRv4 ? ASM_CACHE_ROOT_EX : ASM_CACHE_ROOT;
+            
+            const int size = 260; // MAX_PATH
+            StringBuilder b = new StringBuilder(size);
+            uint tmp = size;
+            GetCachePath(flags, b, ref tmp);
+            return b.ToString();
+        }
+    }
+}

--- a/OmniSharp/Solution/GacInterop.cs
+++ b/OmniSharp/Solution/GacInterop.cs
@@ -1,0 +1,132 @@
+﻿// Copyright (c) 2011 AlphaSierraPapa for the SharpDevelop Team
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+using Mono.Cecil;
+
+namespace OmniSharp.Solution
+{
+    /// <summary>
+    /// Interop with the .NET GAC.
+    /// </summary>
+    static class GacInterop
+    {
+        /// <summary>
+        /// Gets the names of all assemblies in the GAC.
+        /// </summary>
+        public static IEnumerable<AssemblyNameReference> GetGacAssemblyFullNames()
+        {
+            IApplicationContext applicationContext = null;
+            IAssemblyEnum assemblyEnum = null;
+            IAssemblyName assemblyName = null;
+            
+            Fusion.CreateAssemblyEnum(out assemblyEnum, null, null, 2, 0);
+            while (assemblyEnum.GetNextAssembly(out applicationContext, out assemblyName, 0) == 0) {
+                uint nChars = 0;
+                assemblyName.GetDisplayName(null, ref nChars, 0);
+                
+                StringBuilder name = new StringBuilder((int)nChars);
+                assemblyName.GetDisplayName(name, ref nChars, 0);
+                
+                AssemblyNameReference r = null;
+                try {
+                    r = AssemblyNameReference.Parse(name.ToString());
+                } catch (ArgumentException) {
+                } catch (FormatException) {
+                } catch (OverflowException) {
+                }
+                if (r != null)
+                    yield return r;
+            }
+        }
+        
+        #region FindAssemblyInGac
+        // This region is based on code from Mono.Cecil:
+        
+        // Author:
+        //   Jb Evain (jbevain@gmail.com)
+        //
+        // Copyright (c) 2008 - 2010 Jb Evain
+        //
+        // Permission is hereby granted, free of charge, to any person obtaining
+        // a copy of this software and associated documentation files (the
+        // "Software"), to deal in the Software without restriction, including
+        // without limitation the rights to use, copy, modify, merge, publish,
+        // distribute, sublicense, and/or sell copies of the Software, and to
+        // permit persons to whom the Software is furnished to do so, subject to
+        // the following conditions:
+        //
+        // The above copyright notice and this permission notice shall be
+        // included in all copies or substantial portions of the Software.
+        //
+        // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+        // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+        // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+        // NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+        // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+        // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+        // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+        //
+
+        static readonly string[] gac_paths = { Fusion.GetGacPath(false), Fusion.GetGacPath(true) };
+        static readonly string[] gacs = { "GAC_MSIL", "GAC_32", "GAC" };
+        static readonly string[] prefixes = { string.Empty, "v4.0_" };
+        
+        /// <summary>
+        /// Gets the file name for an assembly stored in the GAC.
+        /// </summary>
+        public static string FindAssemblyInNetGac (AssemblyNameReference reference)
+        {
+            // without public key, it can't be in the GAC
+            if (reference.PublicKeyToken == null)
+                return null;
+            
+            for (int i = 0; i < 2; i++) {
+                for (int j = 0; j < gacs.Length; j++) {
+                    var gac = Path.Combine (gac_paths [i], gacs [j]);
+                    var file = GetAssemblyFile (reference, prefixes [i], gac);
+                    if (File.Exists (file))
+                        return file;
+                }
+            }
+
+            return null;
+        }
+        
+        static string GetAssemblyFile (AssemblyNameReference reference, string prefix, string gac)
+        {
+            var gac_folder = new StringBuilder ()
+                .Append (prefix)
+                .Append (reference.Version)
+                .Append ("__");
+
+            for (int i = 0; i < reference.PublicKeyToken.Length; i++)
+                gac_folder.Append (reference.PublicKeyToken [i].ToString ("x2"));
+
+            return Path.Combine (
+                Path.Combine (
+                    Path.Combine (gac, reference.Name), gac_folder.ToString ()),
+                reference.Name + ".dll");
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
If we can't find a DLL using the path hint or the reference assembly folders, attempt to find it in the GAC.

This has only been tested in Windows. I assume this needs to implemented in some other way for Linux/OS X.
