### PR TITLE
Add feature: jumping to any file in the current solution

### DIFF
--- a/OmniSharp/GotoFile/GotoFileHandler.cs
+++ b/OmniSharp/GotoFile/GotoFileHandler.cs
@@ -1,0 +1,32 @@
+﻿using ICSharpCode.NRefactory;
+using ICSharpCode.NRefactory.CSharp.Resolver;
+using ICSharpCode.NRefactory.Semantics;
+using OmniSharp.Common;
+using OmniSharp.Parser;
+using OmniSharp.Solution;
+using System.Linq;
+
+namespace OmniSharp.GotoFile
+{
+    public class GotoFileHandler
+    {
+        ISolution _solution;
+
+        public GotoFileHandler(ISolution solution) {
+            _solution = solution;
+        }
+
+        public QuickFixResponse GetSolutionFiles()
+        {
+            var quickFixes = _solution.Projects
+                .SelectMany(p => p.Files)
+                .Select(f => new QuickFix
+                        { FileName = f.FileName
+                        , Line = 1
+                        , Column = 1
+                        , Text = f.FileName});
+            return new QuickFixResponse(quickFixes);
+        }
+
+    }
+}

--- a/OmniSharp/GotoFile/GotoFileModule.cs
+++ b/OmniSharp/GotoFile/GotoFileModule.cs
@@ -1,0 +1,13 @@
+﻿using Nancy;
+using Nancy.ModelBinding;
+
+namespace OmniSharp.GotoFile {
+    public class GotoFileModule : NancyModule {
+        public GotoFileModule(GotoFileHandler gotoFileHandler) {
+            Post["/gotofile"] = x => {
+                var res = gotoFileHandler.GetSolutionFiles();
+                return Response.AsJson(res);
+            };
+        }
+    }
+}

--- a/OmniSharp/OmniSharp.csproj
+++ b/OmniSharp/OmniSharp.csproj
@@ -243,6 +243,8 @@
     <Compile Include="CurrentFileMembers\CurrentFileMembersAsTreeModule.cs" />
     <Compile Include="CurrentFileMembers\CurrentFileMembersAsTreeResponse.cs" />
     <Compile Include="CurrentFileMembers\CurrentFileMembersAsFlatModule.cs" />
+    <Compile Include="GotoFile\GotoFileModule.cs" />
+    <Compile Include="GotoFile\GotoFileHandler.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />


### PR DESCRIPTION
Simple API that, upon calling, retuns all files in the current
solution as QuickFixes. These can then be navigated in the editor to
jump to them like usual.

I'm hoping CtrlP will take good use of this! It's even better than ido
for emacs.

I'm also adding a feature for the emacs plugin where GotoFile and
currentfilemembersasflat will be called in succession. This should
allow for intuitive and fast navigation. I hope it will be easy to
implement in Vim as well, should you see the need :)
