### PR TITLE
Fix QuickFix Text being empty on interface methods

### DIFF
--- a/OmniSharp/Common/QuickFix.cs
+++ b/OmniSharp/Common/QuickFix.cs
@@ -52,14 +52,15 @@ namespace OmniSharp.Common
         ///   Text contains the type signature and not the body.
         /// </example>
         public static QuickFix ForNonBodyRegion
-            (DomRegion region, IDocument document, DomRegion bodyRegion) {
+            (IUnresolvedEntity entity, IDocument document) {
 
-            var text = GetNonBodyRegion(region, document, bodyRegion);
+            var text = GetNonBodyRegion
+                (entity.Region, document, entity.BodyRegion);
 
             return new QuickFix
-                { FileName = region.FileName
-                , Line     = region.BeginLine
-                , Column   = region.BeginColumn
+                { FileName = entity.Region.FileName
+                , Line     = entity.Region.BeginLine
+                , Column   = entity.Region.BeginColumn
                 , Text     = text};
 
         }
@@ -86,8 +87,12 @@ namespace OmniSharp.Common
             var begin     = document.GetOffset(region.Begin);
             var bodyStart = document.GetOffset(bodyRegion.Begin);
 
-            var typeSignatureLength = bodyStart - begin;
-
+            // Some entities have no body. These include members in
+            // interfaces.
+            bool hasNoBody = bodyStart == begin;
+            var typeSignatureLength = hasNoBody
+				? document.GetOffset(region.End) - begin
+				: bodyStart - begin;
             // Note: We remove extra spaces and newlines from the type
             // signature to make displaying it easier in Vim. Other
             // editors might not have a problem with displaying

--- a/OmniSharp/CurrentFileMembers/Node.cs
+++ b/OmniSharp/CurrentFileMembers/Node.cs
@@ -21,10 +21,7 @@ namespace OmniSharp.CurrentFileMembers {
         /// </summary>
         public Node(IUnresolvedMember member, IDocument document) {
             this.ChildNodes = null;
-            this.Location = QuickFix.ForNonBodyRegion
-                ( member.Region
-                , document
-                , bodyRegion: member.BodyRegion);
+            this.Location = QuickFix.ForNonBodyRegion(member, document);
 
             // Fields' BodyRegion does not include their name for some
             // reason. To prevent the field's name missing, include
@@ -44,9 +41,7 @@ namespace OmniSharp.CurrentFileMembers {
                 { ChildNodes = topLevelTypeDefinition.Members
                     .Select(m => new Node(m, document))
                 , Location = QuickFix.ForNonBodyRegion
-                    ( topLevelTypeDefinition.Region
-                    , document
-                    , bodyRegion: topLevelTypeDefinition.BodyRegion)};
+                    (topLevelTypeDefinition, document)};
 
             return retval;
         }


### PR DESCRIPTION
This fixes a problem where members defined in interfaces would have no
Text property set in their QuickFixes.

NRefactory is a bit funny sometimes. Apparently when a method defined
in an interface does not have a body, its BodyRegion is just the same
as its Region. Weird behaviour.
