### PR TITLE
Files included in cs projects using an "Import" tag are not processed correctly

### DIFF
--- a/OmniSharp/OmniSharp.csproj
+++ b/OmniSharp/OmniSharp.csproj
@@ -76,6 +76,7 @@
     <StartupObject>OmniSharp.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Mono.Cecil.Mdb">
       <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
@@ -251,12 +252,6 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Build.Evaluation\Microsoft.Build.Evaluation.csproj">
-      <Project>{3650EB54-3511-4009-B430-3DA4BBFD9D7F}</Project>
-      <Name>Microsoft.Build.Evaluation</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Files or other settings included in projects using an "Import" tag was not being processed.  Updated to use a more recent version of Microsoft.Build.dll and the issue disappeared.

This may or may not be something you want to merge but I thought I'd send it your way since it did fix a lot of issues for me.
