### PR TITLE
Fix solution not starting on non-cygwin environments

### DIFF
--- a/OmniSharp/config-cygwin.json
+++ b/OmniSharp/config-cygwin.json
@@ -1,0 +1,12 @@
+﻿{
+  "PathReplacements":[
+    {
+      "From":"/cygdrive/c/",
+      "To":"c:\\"
+    },
+    {
+      "From":"/",
+      "To":"\\"
+    }
+  ]
+}

--- a/OmniSharp/config.json
+++ b/OmniSharp/config.json
@@ -1,14 +1,3 @@
 ﻿{
-  "PathReplacements":[
-		/* Example cygwin path replacements
-    {
-      "From":"/cygdrive/c/",
-      "To":"c:\\"
-    },
-    {
-      "From":"/",
-      "To":"\\"
-    }
-		*/
-  ]
+
 }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ and [Emacs OmniSharp plugin](https://github.com/sp3ctum/omnisharp-emacs).
 ####Windows
     git clone https://github.com/nosami/OmniSharpServer.git
     cd OmniSharpServer
+
+    # (if using Cygwin, overwrite the default config file config.json with config-cygwin.json)
+    copy OmniSharp\config-cygwin.json OmniSharp\config.json
+
     msbuild /p:Platform="Any CPU"
     
 


### PR DESCRIPTION
This was caused by the config.json file containing comment
characters. It seems comments are not allowed in JSON (see
https://stackoverflow.com/questions/244777/can-i-comment-a-json-file )

Now the default config file is blank, and a config-cygwin.json file may
be used in a Cygwin environment.
