### PR TITLE
Make /opt/mono work as a prefix

### DIFF
--- a/OmniSharp/Solution/CSharpProject.cs
+++ b/OmniSharp/Solution/CSharpProject.cs
@@ -67,7 +67,10 @@ namespace OmniSharp.Solution
             @"/usr/lib/mono/4.0",
             @"/usr/lib/mono/3.5",
             @"/usr/lib/mono/2.0",
-            @"/opt/mono",
+            @"/opt/mono/lib/mono/4.5",
+            @"/opt/mono/lib/mono/4.0",
+            @"/opt/mono/lib/mono/3.5",
+            @"/opt/mono/lib/mono/2.0",
 
         //OS X Paths
             @"/Library/Frameworks/Mono.Framework/Libraries/mono/4.5",


### PR DESCRIPTION
This PR is just the stuff we discussed on Twitter. Adding these to the paths appears to work for that usage as a temporary measure.

In my (admittedly slightly unusual) usage of mono, I have several versions installed in e.g. `/opt/mono-3.2.8`, `/opt/mono-3.2.6`, `/opt/mono-SOMESHA1` etc, and have the currently "active" version symlinked to `/opt/mono`.
