### PR TITLE
Reload OmniSharpServer configuration on /reloadsolution

### DIFF
--- a/OmniSharp/ReloadSolution/ReloadSolutionModule.cs
+++ b/OmniSharp/ReloadSolution/ReloadSolutionModule.cs
@@ -10,6 +10,11 @@ namespace OmniSharp.ReloadSolution
             Post["/reloadsolution"] = x =>
                 {
                     solution.Reload();
+                    var config = Configuration.ConfigurationLoader.Config;
+                    string mode = config.ClientPathMode.HasValue
+                        ? config.ClientPathMode.Value.ToString()
+                        : null;
+                    Configuration.ConfigurationLoader.Load(mode);
                     return Response.AsJson(true);
                 };
         }


### PR DESCRIPTION
It used to only reload the solution and its files. Now changes done to
the server config file can be tested out without shutting down the
server.

It's kind of trivial, but I thought "why not" :)
