### PR TITLE
Test failure resolving solution file on Windows

### DIFF
--- a/OmniSharp.Tests/Solution/SolutionTest.cs
+++ b/OmniSharp.Tests/Solution/SolutionTest.cs
@@ -32,7 +32,7 @@ namespace OmniSharp.Tests
         [Test]
         public void Should_put_unknown_file_near_to_close_project_file()
         {
-            _solution.ProjectContainingFile (Environment.CurrentDirectory + "/Solution/minimal/minimal/test.cs")
+            _solution.ProjectContainingFile ((Environment.CurrentDirectory + "/Solution/minimal/minimal/test.cs").LowerCaseDriveLetter())
                 .Title.ShouldEqual ("minimal");
         }
     }


### PR DESCRIPTION
This test fails in Windows because the driver letter case is different. I haven't encountered any issues with the ProjectContainingFile method itself.
