### PR TITLE
Code formatting styles

### DIFF
--- a/OmniSharp/Configuration/OmniSharpConfiguration.cs
+++ b/OmniSharp/Configuration/OmniSharpConfiguration.cs
@@ -17,7 +17,45 @@ namespace OmniSharp.Configuration
         public IEnumerable<string> IgnoredCodeIssues { get; set; }
         public TextEditorOptions TextEditorOptions { get; set; }
         public TestCommands TestCommands { get; set; }
-        public CSharpFormattingOptions CSharpFormattingOptions { get; set; }
+        public string CSharpFormattingOptionsName { get; set; }
+        private CSharpFormattingOptions _options;
+        public CSharpFormattingOptions CSharpFormattingOptions
+        {
+            set
+            {
+                switch (CSharpFormattingOptionsName)
+                {
+                    case "KRStyle":
+                        _options = FormattingOptionsFactory.CreateKRStyle();
+                        break;
+                    case "Allman":
+                        _options = FormattingOptionsFactory.CreateAllman();
+                        break;
+                    case "Empty":
+                        _options = FormattingOptionsFactory.CreateEmpty();
+                        break;
+                    case "GNU":
+                        _options = FormattingOptionsFactory.CreateGNU();
+                        break;
+                    case "Mono":
+                        _options = FormattingOptionsFactory.CreateMono();
+                        break;
+                    case "SharpDevelop":
+                        _options = FormattingOptionsFactory.CreateSharpDevelop();
+                        break;
+                    case "Whitesmiths":
+                        _options = FormattingOptionsFactory.CreateWhitesmiths();
+                        break;
+                    default:
+                        _options = value;
+                        break;
+                }
+            }
+            get
+            {
+                return _options;
+            }
+        }
         public bool? UseCygpath { get; set; }
         public PathMode? ClientPathMode { get; set; }
         public PathMode? ServerPathMode { get; set; }

--- a/OmniSharp/config.json
+++ b/OmniSharp/config.json
@@ -24,6 +24,8 @@
     "wrapLineLength": 80
   },
 
+  "CSharpFormattingOptionsName" : "Custom",
+
   "CSharpFormattingOptions": {
     "alignElseInIfStatements": false,
     "alignEmbeddedStatements": true,


### PR DESCRIPTION
Add ability to use one of `FormattingOptionsFactory` default styles or to define custom one in `config.json` by customising `CSharpFormattingOptions` key. 

I am really new in `C#`, so probably you can update `OmniSharpConfiguration` in more convenient way. 

Hope it will help someone :)
