### PR TITLE
added kpm packages folder to list of locations to inspect for vnext

### DIFF
--- a/OmniSharp/Solution/CSharpProject.cs
+++ b/OmniSharp/Solution/CSharpProject.cs
@@ -61,7 +61,8 @@ namespace OmniSharp.Solution
             @"/Library/Frameworks/Mono.Framework/Libraries/mono/4.5",
             @"/Library/Frameworks/Mono.Framework/Libraries/mono/4.0",
             @"/Library/Frameworks/Mono.Framework/Libraries/mono/3.5",
-            @"/Library/Frameworks/Mono.Framework/Libraries/mono/2.0"
+            @"/Library/Frameworks/Mono.Framework/Libraries/mono/2.0",
+            @"~/.kpm/packages"
         };
         private readonly ISolution _solution;
 


### PR DESCRIPTION
Hope this is ok. If you install K via Homebrew as shown in the instructions here https://github.com/aspnet/Home there is now a central packages folder not under each app as in previous apps that appears in ~/.kpm

See screenshot

![screen shot 2014-08-07 at 14 33 58](https://cloud.githubusercontent.com/assets/105126/3842511/f9791802-1e37-11e4-91de-1a355024a400.png)
