### PR TITLE
Error if logging an null error

### DIFF
--- a/OmniSharp/Logger.cs
+++ b/OmniSharp/Logger.cs
@@ -51,7 +51,7 @@ namespace OmniSharp
 
         public void Error(object message)
         {
-            Log(message.ToString());
+            Log(message);
         }
 
         private void Log(object message)


### PR DESCRIPTION
If a null error object is logged, it causes a NullReferenceException.
