### PR TITLE
Don't client convert build executable unless it's intended for the client

### DIFF
--- a/OmniSharp/Build/BuildCommandBuilder.cs
+++ b/OmniSharp/Build/BuildCommandBuilder.cs
@@ -16,10 +16,10 @@ namespace OmniSharp.Build
         {
             get
             {
-                return (PlatformService.IsUnix
+                return PlatformService.IsUnix
                     ? "xbuild"
                     : Path.Combine(System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory(),
-                        "Msbuild.exe")).ApplyPathReplacementsForClient();
+                        "Msbuild.exe");
             }
         }
 

--- a/OmniSharp/Build/BuildCommandModule.cs
+++ b/OmniSharp/Build/BuildCommandModule.cs
@@ -1,4 +1,5 @@
 ﻿using Nancy;
+using OmniSharp.Solution;
 
 namespace OmniSharp.Build
 {
@@ -7,7 +8,7 @@ namespace OmniSharp.Build
         public BuildCommandModule(BuildCommandBuilder commandBuilder)
         {
             Post["/buildcommand"] = x =>
-                Response.AsText(commandBuilder.Executable + " " + commandBuilder.Arguments);
+                Response.AsText(commandBuilder.Executable.ApplyPathReplacementsForClient() + " " + commandBuilder.Arguments);
         }
     }
 }


### PR DESCRIPTION
Causes an error on server-side build if server and client are different modes.
