### PR TITLE
CSharpProjectContent is immutable.

### DIFF
--- a/OmniSharp.Tests/FakeProject.cs
+++ b/OmniSharp.Tests/FakeProject.cs
@@ -26,10 +26,11 @@ namespace OmniSharp.Tests
             Files = new List<CSharpFile>();
             References = new List<IAssemblyReference>();
             ProjectId = id;
-            this.ProjectContent = new CSharpProjectContent();
-            this.ProjectContent.SetAssemblyName(name);
-            this.ProjectContent.SetProjectFileName(name);
-            this.ProjectContent = this.ProjectContent.AddAssemblyReferences(new [] { mscorlib.Value, systemCore.Value });
+            this.ProjectContent
+                = new CSharpProjectContent()
+                .SetAssemblyName(name)
+                .SetProjectFileName(name)
+                .AddAssemblyReferences(new [] { mscorlib.Value, systemCore.Value });
         }
 
         public void AddFile(string source, string fileName="myfile")
@@ -49,6 +50,9 @@ namespace OmniSharp.Tests
             var file = GetFile (fileName);
             file.Content = new StringTextSource(source);
             file.Parse(this, fileName, source);
+
+            this.ProjectContent = this.ProjectContent
+                .AddOrUpdateFiles(file.ParsedFile);
         }
 
         public IProjectContent ProjectContent { get; set; }
@@ -62,6 +66,8 @@ namespace OmniSharp.Tests
         public void AddReference(IAssemblyReference reference)
         {
             References.Add(reference);
+            this.ProjectContent = this.ProjectContent
+                .AddAssemblyReferences(reference);
         }
 
         public void AddReference(string reference)

--- a/OmniSharp.Tests/Rename/FakeSolutionBuilder.cs
+++ b/OmniSharp.Tests/Rename/FakeSolutionBuilder.cs
@@ -25,7 +25,7 @@ namespace OmniSharp.Tests.Rename
             foreach (var project in _projects)
             {
                 // each project references the ones that came before it.
-                newProject.ProjectContent.AddAssemblyReferences(new ProjectReference(project.Name));
+                newProject.AddReference(new ProjectReference(project.Name));
             }
             _projects.Add(newProject);
 

--- a/OmniSharp/Solution/CSharpFile.cs
+++ b/OmniSharp/Solution/CSharpFile.cs
@@ -35,8 +35,6 @@ namespace OmniSharp.Solution
             CSharpParser p = project.CreateParser();
             this.SyntaxTree = p.Parse(Content.CreateReader(), fileName);
             this.ParsedFile = this.SyntaxTree.ToTypeSystem();
-            if(this.Project.ProjectContent != null)
-                this.Project.ProjectContent.AddOrUpdateFiles(this.ParsedFile);
         }
 
         protected IProject Project { get; set; }

--- a/OmniSharp/Solution/CSharpProject.cs
+++ b/OmniSharp/Solution/CSharpProject.cs
@@ -268,7 +268,7 @@ namespace OmniSharp.Solution
                 file = new CSharpFile(this, fileName, source);
                 Files.Add (file);
 
-                this.ProjectContent
+                this.ProjectContent = this.ProjectContent
                     .AddOrUpdateFiles(file.ParsedFile);
             }
             return file;
@@ -279,6 +279,9 @@ namespace OmniSharp.Solution
             var file = GetFile (fileName, source);
             file.Content = new StringTextSource(source);
             file.Parse(this, fileName, source);
+
+            this.ProjectContent = this.ProjectContent
+                .AddOrUpdateFiles(file.ParsedFile);
         }
 
         public CSharpParser CreateParser()

--- a/OmniSharp/Solution/OrphanProject.cs
+++ b/OmniSharp/Solution/OrphanProject.cs
@@ -62,7 +62,7 @@ namespace OmniSharp.Solution
                 file = new CSharpFile(this, fileName, source);
                 Files.Add (file);
 
-                this.ProjectContent
+                this.ProjectContent = this.ProjectContent
                     .AddOrUpdateFiles(file.ParsedFile);
             }
             return file;
@@ -73,6 +73,9 @@ namespace OmniSharp.Solution
             var file = GetFile (fileName, source);
             file.Content = new StringTextSource(source);
             file.Parse(this, fileName, source);
+
+            this.ProjectContent = this.ProjectContent
+                .AddOrUpdateFiles(file.ParsedFile);
         }
 
         public CSharpParser CreateParser()


### PR DESCRIPTION
All of its modify methods instead return a modified clone, thus calling them in void context has no effect. 
