### PR TITLE
Add references to all dlls in ~./kpm/packages for temp ASP.NET vNext fix

### DIFF
--- a/OmniSharp/Solution/CSharpProject.cs
+++ b/OmniSharp/Solution/CSharpProject.cs
@@ -106,6 +106,7 @@ namespace OmniSharp.Solution
 
             AddMsCorlib();
             AddReference(LoadAssembly(FindAssembly("System.Core")));
+            AddAllKPMPackages();
             this.ProjectContent = new CSharpProjectContent()
                 .SetAssemblyName(AssemblyName)
                 .AddAssemblyReferences(References)
@@ -171,6 +172,34 @@ namespace OmniSharp.Solution
                 .SetAssemblyName(AssemblyName)
                 .AddAssemblyReferences(References)
                 .AddOrUpdateFiles(Files.Select(f => f.ParsedFile));
+        }
+
+        private void AddAllKPMPackages()
+        {
+            try
+            {
+                var userDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                var folder = new DirectoryInfo(Path.Combine(userDir, ".kpm/packages"));
+                var dlls = folder.EnumerateFiles("*.dll", SearchOption.AllDirectories);
+                foreach (var dll in dlls)
+                {
+                    Console.WriteLine(dll.FullName);
+                    try
+                    {
+                        AddReference(dll.FullName);
+                    }
+                    catch(System.BadImageFormatException)
+                    {
+                        // Ignore native dlls
+                    }
+
+                }
+            }
+            catch (DirectoryNotFoundException)
+            {
+                // Definitely not ASP.NET vNext if no .kpm/packages
+            }
+
         }
 
         string GetAssemblyFileNameFromHintPath(Microsoft.Build.Evaluation.Project p, Microsoft.Build.Evaluation.ProjectItem item)


### PR DESCRIPTION
This is definitely in a "Works on My Machine, No Guarantees This Won't Kill Your Puppy"&trade; kind of state. From what I can tell, the `CSharpProject` constructor that I'm invoking this method in will only be called in the solution-less case, so hopefully this won't affect people using OmniSharp for standard .NET projects. 

I'm boiling the ocean and just grabbing anything that exists in the kpm/packages directory. That could cause all kinds of problems depending on the state of your packages cache, not to mention being slow, but it works for the demo I want to do, since I can just clean the directory out prior to demoing and guarantee that there's nothing else in there that I don't want.

Also discovered that it doesn't seem to like the `~` notation for the user directory, so I used the SpecialDirectories enum to find it instead.

Hope you can make use of this, my apologies if it introduces too many bad side effects!
