### PR TITLE
Adding OmniSharp config loading argument  validation

### DIFF
--- a/OmniSharp/Configuration/PathReplacement.cs
+++ b/OmniSharp/Configuration/PathReplacement.cs
@@ -14,6 +14,11 @@ namespace OmniSharp.Configuration
 
         public static OmniSharpConfiguration Load(string configLocation, string clientMode)
         {
+            if (string.IsNullOrEmpty(configLocation))
+            {
+                string executableLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                configLocation = Path.Combine(executableLocation, "config.json");
+            }
             var config = File.ReadAllText(configLocation);
             _config = new Nancy.Json.JavaScriptSerializer().Deserialize<OmniSharpConfiguration>(config);
 


### PR DESCRIPTION
Adding minimum path argument validation to OmniSharpConfiguration Load,
and default path when validation fails.  This is similar to the
behavior prior to commits 9b179f1 / 91329b9.

Without this, a null or empty string as configLocation will cause an exception to be thrown.  First noticed when trying to update the OmniSharpServer submodule in ycmd, specifically the ReloadSolution test.  If this isn't the preferred method, please let me know what is more suitable and I'll update.
