### PR TITLE
fix error check and find usage not effected by conditionalSymbols.

### DIFF
--- a/OmniSharp/FindUsages/FindUsagesHandler.cs
+++ b/OmniSharp/FindUsages/FindUsagesHandler.cs
@@ -121,7 +121,12 @@ namespace OmniSharp.FindUsages
                     Parallel.ForEach(interesting.Distinct(), file =>
                         {
                             string text = _solution.GetFile(file.FileName.LowerCaseDriveLetter()).Content.Text;
-                            var unit = new CSharpParser().Parse(text, file.FileName);
+                            SyntaxTree unit ;
+                            if(project.CompilerSettings!=null){
+                            	unit = new CSharpParser(project.CompilerSettings).Parse(text, file.FileName);
+                            }else{
+                            	unit = new CSharpParser().Parse(text, file.FileName);
+                            }
 
                             foreach (var scope in searchScopes)
                             {

--- a/OmniSharp/SemanticErrors/SemanticErrorsHandler.cs
+++ b/OmniSharp/SemanticErrors/SemanticErrorsHandler.cs
@@ -31,7 +31,12 @@ namespace OmniSharp.SemanticErrors
             var project = _solution.ProjectContainingFile(request.FileName);
             project.UpdateFile(request.FileName, request.Buffer);
             var solutionSnapshot = new DefaultSolutionSnapshot(_solution.Projects.Select(i => i.ProjectContent));
-            var syntaxTree = new CSharpParser().Parse(request.Buffer, request.FileName);
+            SyntaxTree syntaxTree;
+            if(project.CompilerSettings!=null){
+            	syntaxTree = new CSharpParser(project.CompilerSettings).Parse(request.Buffer, request.FileName);
+            }else{
+            	syntaxTree = new CSharpParser().Parse(request.Buffer, request.FileName);
+            }
             var resolver = new CSharpAstResolver(solutionSnapshot.GetCompilation(project.ProjectContent), syntaxTree);
             var navigator = new SemanticErrorsNavigator();
             resolver.ApplyNavigator(navigator);

--- a/OmniSharp/SyntaxErrors/SyntaxErrorsHandler.cs
+++ b/OmniSharp/SyntaxErrors/SyntaxErrorsHandler.cs
@@ -2,14 +2,27 @@ using System.Linq;
 using ICSharpCode.NRefactory.CSharp;
 using OmniSharp.Common;
 using OmniSharp.Solution;
+using OmniSharp.Parser;
+using OmniSharp.Configuration;
 
 namespace OmniSharp.SyntaxErrors
 {
     public class SyntaxErrorsHandler
     {
+		private readonly ISolution _solution;
+		public SyntaxErrorsHandler(ISolution solution)
+		{
+			_solution = solution;
+		}
+
         public SyntaxErrorsResponse FindSyntaxErrors(Request request)
         {
-            var syntaxTree = new CSharpParser().Parse(request.Buffer, request.FileName);
+            var parser = new CSharpParser ();
+            var project = _solution.ProjectContainingFile(request.FileName);
+            if (project.CompilerSettings != null) {
+            	parser.CompilerSettings = project.CompilerSettings;
+            }
+            var syntaxTree = parser.Parse(request.Buffer, request.FileName);
 
             var filename = request.FileName.ApplyPathReplacementsForClient();
 


### PR DESCRIPTION
Fixed three point CSharpParser usage not use CompilerSettings.
