### PR TITLE
Fixing build (xbuild): unused local variable in AutoComplete/SnippetGenerator.cs

### DIFF
--- a/OmniSharp/AutoComplete/SnippetGenerator.cs
+++ b/OmniSharp/AutoComplete/SnippetGenerator.cs
@@ -221,7 +221,6 @@ namespace OmniSharp.AutoComplete
                     if (member is IMethod)
                     {
                         var method = ((IMethod)member);
-                        var typeParams = method.TypeParameters;
 
                         var methodParameterTypeArguments =
                             from p in method.Parameters


### PR DESCRIPTION
Buidling with xbuild (default settings) leads to a compile error.
This patch fixes it.
