### PR TITLE
Add Cygwin path replacement for Rename/Override

### DIFF
--- a/OmniSharp/Rename/ModifiedFileResponse.cs
+++ b/OmniSharp/Rename/ModifiedFileResponse.cs
@@ -1,7 +1,10 @@
-﻿namespace OmniSharp.Rename
+﻿using OmniSharp.Solution;
+
+namespace OmniSharp.Rename
 {
     public class ModifiedFileResponse
     {
+        private string _fileName;
         public ModifiedFileResponse() {}
 
         public ModifiedFileResponse(string fileName, string buffer) {
@@ -9,7 +12,14 @@
             this.Buffer = buffer;
         }
 
-        public string FileName { get; set; }
+        public string FileName
+        {
+            get { return _fileName; }
+            set
+            {
+                _fileName = value.ApplyPathReplacementsForClient();
+            }
+        }
         public string Buffer { get; set; }
 
     }


### PR DESCRIPTION
Hi,
This issue prevents OmniSharpRename from working in omnisharp-vim under Cygwin.
