### PR TITLE
Use "omnisharp.json" from solution path as config file automatically 

### DIFF
--- a/OmniSharp/Program.cs
+++ b/OmniSharp/Program.cs
@@ -23,7 +23,11 @@ namespace OmniSharp
             // Determine the default location for the server side config.json file.
             // The user may override this with a command line option if they want.
             string executableLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            string configLocation = Path.Combine(executableLocation, "config.json");
+            string configLocation = Path.Combine(solutionPath, "omnisharp.json");
+            if (!File.Exists(configLocation))
+            {
+                configLocation = Path.Combine(executableLocation, "config.json");
+            }
 
             var port = 2000;
             Verbosity verbosity = Verbosity.Debug;

--- a/OmniSharp/config.json
+++ b/OmniSharp/config.json
@@ -17,7 +17,7 @@
   ],*/
 
   /* Native Emacs on Windows path replacements
-     
+
   "PathReplacements": [
       {
           "From":"/",
@@ -47,6 +47,17 @@
     "wrapLineLength": 80
   },
 
+  /*
+    Available names:
+    * Custom
+    * KRStyle
+    * Allman
+    * Empty
+    * GNU
+    * Mono
+    * SharpDevelop
+    * Whitesmiths
+   */
   "CSharpFormattingOptionsName" : "Custom",
 
   "CSharpFormattingOptions": {


### PR DESCRIPTION
First commit just adds available formatting options (yay to 29fdb7df890337777a5cce62bcf7bf49a60a3ca5 commit).
Second commit allows user to add `omnisharp.json` file to solution directory that will be loaded automatically instead of default `config.json` in executable directory. Should be harmless for all people that will not use this feature and pretty useful for those who has different configurations across different solutions. Not critical, but anyway. 
