### PR TITLE
Added tests for property initialiser

### DIFF
--- a/OmniSharp.Tests/AutoComplete/BugFixTests.cs
+++ b/OmniSharp.Tests/AutoComplete/BugFixTests.cs
@@ -112,5 +112,84 @@ public class MyClass
                     }
                 }").ShouldContain("String(");
         }
+
+        [Test]
+        public void WhenOneSpace_ThenShouldCompleteWithProperty()
+        {
+            CompletionsFor(
+                @"
+                public class MyClass
+                { 
+                    public class Foo 
+                    {
+                        public string Bar { get; set; }
+                    }   
+
+                    public MyClass()
+                    {
+                        var d = new Foo{ $
+                    }
+                }").ShouldContain("Bar");
+        }
+
+        [Test]
+        public void WhenNoSpace_ThenShouldCompleteWithProperty()
+        {
+            CompletionsFor(
+                @"
+                public class MyClass
+                { 
+                    public class Foo 
+                    {
+                        public string Bar { get; set; }
+                    }   
+
+                    public MyClass()
+                    {
+                        var d = new Foo{$
+                    }
+                }").ShouldContain("Bar");
+        }
+
+        [Test]
+        public void WhenNewLine_ThenShouldCompleteWithProperty()
+        {
+            CompletionsFor(
+                @"
+                public class MyClass
+                { 
+                    public class Foo 
+                    {
+                        public string Bar { get; set; }
+                    }   
+
+                    public MyClass()
+                    {
+                        var d = new Foo {
+                        $
+                    }
+                }").ShouldContain("Bar");
+        }
+
+        [Test]
+        public void WhenNewLineCol1_ThenShouldCompleteWithProperty()
+        {
+            CompletionsFor(
+@"
+public class MyClass
+{ 
+    public class Foo 
+    {
+        public string Bar { get; set; }
+    }   
+
+    public MyClass()
+    {
+        var d = new Foo {
+$
+    }
+}"
+            ).ShouldContain("Bar");
+        }
     }
 }


### PR DESCRIPTION
Two work, two don't - depending on where you place the cursor.

Reproducing the problem discussed in omnisharp-brackets:
https://github.com/OmniSharp/omnisharp-brackets/issues/5#issuecomment-70735514
