### PR TITLE
Fix doubling namespaces in FindSymbolsHandler.FindAllSymbols()

### DIFF
--- a/OmniSharp/FindSymbols/FindSymbolsHandler.cs
+++ b/OmniSharp/FindSymbols/FindSymbolsHandler.cs
@@ -26,8 +26,7 @@ namespace OmniSharp.FindSymbols
 
             var quickfixes = types.Select(t => new QuickFix
                 {
-                    Text = t.Name + "\t(in " + t.Namespace
-                        + "." + t.DeclaringTypeDefinition.FullTypeName + ")",
+                    Text = t.Name + "\t(in " + t.DeclaringTypeDefinition.FullTypeName + ")",
                     FileName = t.UnresolvedFile.FileName,
                     Column = t.Region.BeginColumn,
                     Line = t.Region.BeginLine


### PR DESCRIPTION
Small fix in FindSymbolsHandler.FindAllSymbols().