### PR TITLE
Fix for handling FileNotFoundException a project file listed in solution.

### DIFF
--- a/OmniSharp/Solution/CSharpProject.cs
+++ b/OmniSharp/Solution/CSharpProject.cs
@@ -110,6 +110,11 @@ namespace OmniSharp.Solution
                 logger.Error("Directory not found - " + FileName);
                 return;
             }
+            catch (FileNotFoundException)
+            {
+                logger.Error("File not found - " + FileName);
+                return;
+            }
 
             AssemblyName = project.GetPropertyValue("AssemblyName");
 


### PR DESCRIPTION
When a .csproj file is listed on a Solution, but the file does not exist (but the directory does exists), a FileNotFoundException is thrown by framework.

OmniSharp server is handling only DirectoryNotFound exception. This is causing OmniSharpServer to crash under this situation.