### PR TITLE
Try to use MSBuild from VS2013, instead of MSBuild from .NET 4.0

### DIFF
--- a/OmniSharp/Build/BuildCommandBuilder.cs
+++ b/OmniSharp/Build/BuildCommandBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using OmniSharp.Solution;
 using OmniSharp.Configuration;
+using Microsoft.Win32;
 
 namespace OmniSharp.Build
 {
@@ -23,9 +24,11 @@ namespace OmniSharp.Build
             {
                 return PlatformService.IsUnix
                     ? "xbuild"
-                    : Path.Combine(
-                        _config.MSBuildPath ?? System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory(),
-                        "Msbuild.exe");
+                    : string.Format("\"{0}\"", Path.Combine(
+                        _config.MSBuildPath ??
+                        Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\MSBuild\ToolsVersions\12.0", "MSBuildToolsPath", null) as string ??
+                        System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory(),
+                        "Msbuild.exe"));
             }
         }
 


### PR DESCRIPTION
Sometimes, you may not be able to compile a VS2013 project using MSBuild from .NET 4.0.

Example: compiling a VSTO project, having VSTO up to date, would fail, because of new parameter in SignFile task.

The quotes are needed because in a 64bits Windows, it will be located inside "C:\Program Files (x86)\MSBuild\".