### PR TITLE
Fix crash on missing Name attribute in a ProjectReference

### DIFF
--- a/OmniSharp/Solution/CSharpProject.cs
+++ b/OmniSharp/Solution/CSharpProject.cs
@@ -239,7 +239,10 @@ namespace OmniSharp.Solution
         {
             foreach (Microsoft.Build.Evaluation.ProjectItem item in p.GetItems("ProjectReference"))
             {
-                var projectName = item.GetMetadataValue("Name");
+                var projectName = item.HasMetadata("Name") 
+                    ? item.GetMetadataValue("Name") 
+                    : Path.GetFileNameWithoutExtension(item.EvaluatedInclude);
+
                 var referenceGuid = Guid.Parse(item.GetMetadataValue("Project"));
                 _logger.Debug("Adding project reference {0}, {1}", projectName, referenceGuid);
                 AddReference(new ProjectReference(_solution, projectName, referenceGuid));


### PR DESCRIPTION
The "Name" attribute is not actually required in a ProjectReference, as it turns out. Some .sln files I work with don't have it.

If it doesn't exist, the resulting exception from .First causes the OmniSharp server to get into a very bad state - the omnisharp-emacs package actually hangs Emacs waiting for it to respond, which it never will.