### PR TITLE
Fixed NullReferenceException when project context not found

### DIFF
--- a/OmniSharp/Build/BuildCommandModule.cs
+++ b/OmniSharp/Build/BuildCommandModule.cs
@@ -9,7 +9,7 @@ namespace OmniSharp.Build
         public BuildCommandModule(BuildCommandBuilder commandBuilder)
         {
             Post["BuildCommand", "/buildcommand"] = x =>
-                Response.AsText(commandBuilder.Executable.ApplyPathReplacementsForClient() + " " + commandBuilder.Arguments);
+                Response.AsText(commandBuilder.Executable.ApplyPathReplacementsForClient() + " " + commandBuilder.BuildArguments(true));
 
             Post["BuildTarget", "/buildtarget"] = x =>
             {

--- a/OmniSharp/Build/BuildHandler.cs
+++ b/OmniSharp/Build/BuildHandler.cs
@@ -30,7 +30,7 @@ namespace OmniSharp.Build
             var startInfo = new ProcessStartInfo
                 {
                     FileName = build,
-                    Arguments = _commandBuilder.Arguments,
+                    Arguments = _commandBuilder.BuildArguments(true),
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     RedirectStandardInput = true,
@@ -62,8 +62,8 @@ namespace OmniSharp.Build
             if (e.Data == null)
                 return;
 
-            if (e.Data == "Build succeeded.")
-                _response.Success = true;
+            //if (e.Data == "Build succeeded.")
+             //   _response.Success = true;
             var quickfix = _logParser.Parse(e.Data);
             if(quickfix != null)
                 _quickFixes.Add(quickfix);

--- a/OmniSharp/Build/BuildTargetRequest.cs
+++ b/OmniSharp/Build/BuildTargetRequest.cs
@@ -4,6 +4,8 @@ namespace OmniSharp.Build
 {
     public class BuildTargetRequest : Request
     {
+        public string Project { get; set; }
+
         public BuildType Type { get; set; }
 
         public BuildConfiguration Configuration { get; set; }

--- a/OmniSharp/FindProjects/FindProjectsHandler.cs
+++ b/OmniSharp/FindProjects/FindProjectsHandler.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Linq;
+using OmniSharp.Common;
+using OmniSharp.Solution;
+
+namespace OmniSharp.FindProjects
+{
+    public class FindProjectsHandler
+    {
+        readonly ISolution _solution;
+        public FindProjectsHandler(ISolution solution)
+        {
+            _solution = solution;
+        }
+
+        public QuickFixResponse FindAllProjects()
+        {
+            
+            var quickfixes = _solution.Projects.OrderBy(x => x.Title).Select(t => new QuickFix
+                {
+                    Text = t.Title,
+                    FileName = t.FileName
+                });
+
+            return new QuickFixResponse(quickfixes);
+        }
+        
+    }
+}

--- a/OmniSharp/FindProjects/FindProjectsHandler.cs
+++ b/OmniSharp/FindProjects/FindProjectsHandler.cs
@@ -16,7 +16,10 @@ namespace OmniSharp.FindProjects
         public QuickFixResponse FindAllProjects()
         {
             
-            var quickfixes = _solution.Projects.OrderBy(x => x.Title).Select(t => new QuickFix
+            var quickfixes = _solution.Projects
+                .Where(x => x.Title != OrphanProject.ProjectFileName)
+                .OrderBy(x => x.Title)
+                .Select(t => new QuickFix
                 {
                     Text = t.Title,
                     FileName = t.FileName

--- a/OmniSharp/FindProjects/FindProjectsModule.cs
+++ b/OmniSharp/FindProjects/FindProjectsModule.cs
@@ -1,0 +1,15 @@
+using Nancy;
+namespace OmniSharp.FindProjects
+{
+    public class FindProjectsModule : NancyModule
+    {
+       public FindProjectsModule(FindProjectsHandler handler)
+       {
+           Post["FindProjects", "/findprojects"] = x =>
+           {
+               var res = handler.FindAllProjects();
+               return Response.AsJson(res);
+           };
+       } 
+    }
+}

--- a/OmniSharp/OmniSharp.csproj
+++ b/OmniSharp/OmniSharp.csproj
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,8 +8,7 @@
     <RootNamespace>OmniSharp</RootNamespace>
     <AssemblyName>OmniSharp</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
+    <TargetFrameworkProfile></TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
   </PropertyGroup>
@@ -315,6 +313,8 @@
     <Compile Include="Common\Metadata\RequestMetadataProvider.cs" />
     <Compile Include="ProcessExtensions.cs" />
     <Compile Include="PlatformHelper.cs" />
+    <Compile Include="FindProjects\FindProjectsHandler.cs" />
+    <Compile Include="FindProjects\FindProjectsModule.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/OmniSharp/Solution/OrphanProject.cs
+++ b/OmniSharp/Solution/OrphanProject.cs
@@ -12,6 +12,7 @@ namespace OmniSharp.Solution
     /// </summary>
     public class OrphanProject : Project
     {
+        public const string ProjectFileName = "OrphanProject";
         public OrphanProject(IFileSystem fileSystem, Logger logger) : base(fileSystem, logger)
         {
             Title = "Orphan Project";
@@ -20,11 +21,11 @@ namespace OmniSharp.Solution
             ProjectId = Guid.NewGuid();
 
             References = new List<IAssemblyReference>();
-            FileName = "OrphanProject";
+            FileName = ProjectFileName;
             string mscorlib = FindAssembly("mscorlib");
             Console.WriteLine(mscorlib);
             ProjectContent = new CSharpProjectContent()
-                .SetAssemblyName("OrphanProject")
+                .SetAssemblyName(ProjectFileName)
                 .AddAssemblyReferences(LoadAssembly(mscorlib));
         }
 

--- a/OmniSharp/Solution/ProjectFinder.cs
+++ b/OmniSharp/Solution/ProjectFinder.cs
@@ -20,7 +20,11 @@ namespace OmniSharp.Solution
 
             IProject sourceProject = _solution.Projects.FirstOrDefault(p => p.ProjectContent.FullAssemblyName == contextAssemblyName);
             var projectsThatReferenceUsage = from p in _solution.Projects
-            where p.References.Any(r => r.Resolve(context).FullAssemblyName == contextAssemblyName) || p == sourceProject
+            where p.References.Any(r => {
+                    var ctx = r.Resolve(context);
+                    if (ctx == null) return false;
+                    return ctx.FullAssemblyName == contextAssemblyName;
+                    }) || p == sourceProject
             select p;
             return projectsThatReferenceUsage;
         }


### PR DESCRIPTION
I managed to raise this error while running :OmniSharpFindImplementations.

It seems that in my solution with several projects (40+) the server is unable to resolve the context of one of the project.



```
00053704 System.NullReferenceException: Object reference not set to an instance of an object.
   at OmniSharp.Solution.ProjectFinder.<>c__DisplayClass3.<FindProjectsReferencing>b__2(IAssemblyReference r) in d:\Projects\omnisharp-vim\server\OmniSharp\Solution\ProjectFinder.cs:line 23
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
   at OmniSharp.Solution.ProjectFinder.<>c__DisplayClass3.<FindProjectsReferencing>b__1(IProject p) in d:\Projects\omnisharp-vim\server\OmniSharp\Solution\ProjectFinder.cs:line 23
   at System.Linq.Enumerable.WhereListIterator`1.MoveNext()
   at System.Linq.Enumerable.<SelectManyIterator>d__1`2.MoveNext()
   at OmniSharp.GotoImplementation.GotoImplementationHandler.GetMemberResponse(ITypeResolveContext rctx, MemberResolveResult resolveResult) in d:\Projects\omnisharp-vim\server\OmniSharp\GotoImplementation\GotoImplementationHandle
   at OmniSharp.GotoImplementation.GotoImplementationHandler.FindDerivedMembersAsQuickFixes(GotoImplementationRequest request) in d:\Projects\omnisharp-vim\server\OmniSharp\GotoImplementation\GotoImplementationHandler.cs:line 47
   at OmniSharp.GotoImplementation.GotoImplementationModule.<>c__DisplayClass2.<.ctor>b__0(Object x) in d:\Projects\omnisharp-vim\server\OmniSharp\GotoImplementation\GotoImplementationModule.cs:line 15
   at CallSite.Target(Closure , CallSite , Func`2 , Object )
   at Nancy.Routing.Route.<>c__DisplayClass4.<Wrap>b__3(Object parameters, CancellationToken context)
```
##### Solution
A simple null check fixes it.