### PR TITLE
Allow usage on case-sensitive OS X filesystems

### DIFF
--- a/OmniSharp/Solution/AssemblySearch.cs
+++ b/OmniSharp/Solution/AssemblySearch.cs
@@ -47,10 +47,10 @@ namespace OmniSharp.Solution
             @"/opt/mono/lib/mono/2.0",
 
             //OS X Paths
-            @"/Library/Frameworks/Mono.Framework/Libraries/mono/4.5",
-            @"/Library/Frameworks/Mono.Framework/Libraries/mono/4.0",
-            @"/Library/Frameworks/Mono.Framework/Libraries/mono/3.5",
-            @"/Library/Frameworks/Mono.Framework/Libraries/mono/2.0",
+            @"/Library/Frameworks/Mono.framework/Libraries/mono/4.5",
+            @"/Library/Frameworks/Mono.framework/Libraries/mono/4.0",
+            @"/Library/Frameworks/Mono.framework/Libraries/mono/3.5",
+            @"/Library/Frameworks/Mono.framework/Libraries/mono/2.0",
             @"~/.kpm/packages"
         };
     }


### PR DESCRIPTION
On my OS X Yosemite machine, which is running a case-sensitive file system, omnisharp server couldn't find the proper assemblies. This fixed the issue.