### PR TITLE
Added ability to build specific project

### DIFF
--- a/OmniSharp/Build/BuildCommandModule.cs
+++ b/OmniSharp/Build/BuildCommandModule.cs
@@ -9,7 +9,7 @@ namespace OmniSharp.Build
         public BuildCommandModule(BuildCommandBuilder commandBuilder)
         {
             Post["BuildCommand", "/buildcommand"] = x =>
-                Response.AsText(commandBuilder.Executable.ApplyPathReplacementsForClient() + " " + commandBuilder.Arguments);
+                Response.AsText(commandBuilder.Executable.ApplyPathReplacementsForClient() + " " + commandBuilder.BuildArguments(true));
 
             Post["BuildTarget", "/buildtarget"] = x =>
             {

--- a/OmniSharp/Build/BuildHandler.cs
+++ b/OmniSharp/Build/BuildHandler.cs
@@ -30,7 +30,7 @@ namespace OmniSharp.Build
             var startInfo = new ProcessStartInfo
                 {
                     FileName = build,
-                    Arguments = _commandBuilder.Arguments,
+                    Arguments = _commandBuilder.BuildArguments(true),
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     RedirectStandardInput = true,
@@ -62,8 +62,8 @@ namespace OmniSharp.Build
             if (e.Data == null)
                 return;
 
-            if (e.Data == "Build succeeded.")
-                _response.Success = true;
+            //if (e.Data == "Build succeeded.")
+             //   _response.Success = true;
             var quickfix = _logParser.Parse(e.Data);
             if(quickfix != null)
                 _quickFixes.Add(quickfix);

--- a/OmniSharp/Build/BuildTargetRequest.cs
+++ b/OmniSharp/Build/BuildTargetRequest.cs
@@ -4,6 +4,8 @@ namespace OmniSharp.Build
 {
     public class BuildTargetRequest : Request
     {
+        public string Project { get; set; }
+
         public BuildType Type { get; set; }
 
         public BuildConfiguration Configuration { get; set; }

--- a/OmniSharp/FindProjects/FindProjectsHandler.cs
+++ b/OmniSharp/FindProjects/FindProjectsHandler.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Linq;
+using OmniSharp.Common;
+using OmniSharp.Solution;
+
+namespace OmniSharp.FindProjects
+{
+    public class FindProjectsHandler
+    {
+        readonly ISolution _solution;
+        public FindProjectsHandler(ISolution solution)
+        {
+            _solution = solution;
+        }
+
+        public QuickFixResponse FindAllProjects()
+        {
+            
+            var quickfixes = _solution.Projects.OrderBy(x => x.Title).Select(t => new QuickFix
+                {
+                    Text = t.Title,
+                    FileName = t.FileName
+                });
+
+            return new QuickFixResponse(quickfixes);
+        }
+        
+    }
+}

--- a/OmniSharp/FindProjects/FindProjectsHandler.cs
+++ b/OmniSharp/FindProjects/FindProjectsHandler.cs
@@ -8,25 +8,19 @@ namespace OmniSharp.FindProjects
     public class FindProjectsHandler
     {
         readonly ISolution _solution;
+
         public FindProjectsHandler(ISolution solution)
         {
             _solution = solution;
         }
 
-        public QuickFixResponse FindAllProjects()
+        public FindProjectsResponse FindAllProjects()
         {
-            
-            var quickfixes = _solution.Projects
+            var projects = _solution.Projects
                 .Where(x => x.Title != OrphanProject.ProjectFileName)
                 .OrderBy(x => x.Title)
-                .Select(t => new QuickFix
-                {
-                    Text = t.Title,
-                    FileName = t.FileName
-                });
-
-            return new QuickFixResponse(quickfixes);
+                .Select(t => new MsBuildProject(t));
+            return new FindProjectsResponse { MSBuild = new MsBuildWorkspaceInformation{ Projects = projects }};
         }
-        
     }
 }

--- a/OmniSharp/FindProjects/FindProjectsHandler.cs
+++ b/OmniSharp/FindProjects/FindProjectsHandler.cs
@@ -16,7 +16,10 @@ namespace OmniSharp.FindProjects
         public QuickFixResponse FindAllProjects()
         {
             
-            var quickfixes = _solution.Projects.OrderBy(x => x.Title).Select(t => new QuickFix
+            var quickfixes = _solution.Projects
+                .Where(x => x.Title != OrphanProject.ProjectFileName)
+                .OrderBy(x => x.Title)
+                .Select(t => new QuickFix
                 {
                     Text = t.Title,
                     FileName = t.FileName

--- a/OmniSharp/FindProjects/FindProjectsModule.cs
+++ b/OmniSharp/FindProjects/FindProjectsModule.cs
@@ -1,0 +1,15 @@
+using Nancy;
+namespace OmniSharp.FindProjects
+{
+    public class FindProjectsModule : NancyModule
+    {
+       public FindProjectsModule(FindProjectsHandler handler)
+       {
+           Post["FindProjects", "/findprojects"] = x =>
+           {
+               var res = handler.FindAllProjects();
+               return Response.AsJson(res);
+           };
+       } 
+    }
+}

--- a/OmniSharp/FindProjects/FindProjectsModule.cs
+++ b/OmniSharp/FindProjects/FindProjectsModule.cs
@@ -5,7 +5,7 @@ namespace OmniSharp.FindProjects
     {
        public FindProjectsModule(FindProjectsHandler handler)
        {
-           Post["FindProjects", "/findprojects"] = x =>
+           Post["Projects", "/projects"] = x =>
            {
                var res = handler.FindAllProjects();
                return Response.AsJson(res);

--- a/OmniSharp/FindProjects/FindProjectsResponse.cs
+++ b/OmniSharp/FindProjects/FindProjectsResponse.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using OmniSharp.Solution;
+
+namespace OmniSharp.FindProjects
+{
+    public class FindProjectsResponse
+    {
+        public MsBuildWorkspaceInformation MSBuild { get; set; }
+    }
+}

--- a/OmniSharp/FindProjects/MsBuildProject.cs
+++ b/OmniSharp/FindProjects/MsBuildProject.cs
@@ -1,0 +1,19 @@
+using System;
+using OmniSharp.Solution;
+
+namespace OmniSharp.FindProjects
+{
+    public class MsBuildProject
+    {
+        public Guid ProjectGuid { get; set; }
+        public string Path { get; set; }
+        public string AssemblyName { get; set; }
+
+        public MsBuildProject(IProject p)
+        {
+            AssemblyName = p.Title;
+            Path = p.FileName;
+            ProjectGuid = p.ProjectId;
+        }
+    }
+}

--- a/OmniSharp/FindProjects/MsBuildWorkspaceInformation.cs
+++ b/OmniSharp/FindProjects/MsBuildWorkspaceInformation.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace OmniSharp.FindProjects
+{
+    public class MsBuildWorkspaceInformation
+    {
+        public string SolutionPath { get; set; }
+        public IEnumerable<MsBuildProject> Projects { get; set; }
+    }
+}

--- a/OmniSharp/OmniSharp.csproj
+++ b/OmniSharp/OmniSharp.csproj
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,8 +8,7 @@
     <RootNamespace>OmniSharp</RootNamespace>
     <AssemblyName>OmniSharp</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
+    <TargetFrameworkProfile></TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
   </PropertyGroup>
@@ -315,6 +313,8 @@
     <Compile Include="Common\Metadata\RequestMetadataProvider.cs" />
     <Compile Include="ProcessExtensions.cs" />
     <Compile Include="PlatformHelper.cs" />
+    <Compile Include="FindProjects\FindProjectsHandler.cs" />
+    <Compile Include="FindProjects\FindProjectsModule.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/OmniSharp/OmniSharp.csproj
+++ b/OmniSharp/OmniSharp.csproj
@@ -315,6 +315,9 @@
     <Compile Include="PlatformHelper.cs" />
     <Compile Include="FindProjects\FindProjectsHandler.cs" />
     <Compile Include="FindProjects\FindProjectsModule.cs" />
+    <Compile Include="FindProjects\FindProjectsResponse.cs" />
+    <Compile Include="FindProjects\MsBuildProject.cs" />
+    <Compile Include="FindProjects\MsBuildWorkspaceInformation.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/OmniSharp/Solution/OrphanProject.cs
+++ b/OmniSharp/Solution/OrphanProject.cs
@@ -12,6 +12,7 @@ namespace OmniSharp.Solution
     /// </summary>
     public class OrphanProject : Project
     {
+        public const string ProjectFileName = "OrphanProject";
         public OrphanProject(IFileSystem fileSystem, Logger logger) : base(fileSystem, logger)
         {
             Title = "Orphan Project";
@@ -20,11 +21,11 @@ namespace OmniSharp.Solution
             ProjectId = Guid.NewGuid();
 
             References = new List<IAssemblyReference>();
-            FileName = "OrphanProject";
+            FileName = ProjectFileName;
             string mscorlib = FindAssembly("mscorlib");
             Console.WriteLine(mscorlib);
             ProjectContent = new CSharpProjectContent()
-                .SetAssemblyName("OrphanProject")
+                .SetAssemblyName(ProjectFileName)
                 .AddAssemblyReferences(LoadAssembly(mscorlib));
         }
 


### PR DESCRIPTION
In my solution I have lots of projects (40+) and I needed the ability to build a specific project as building the whole solution everytime would take too long.

Added features:
- Return list of all projects
- Build/Rebuild/Clean specific project

I also have patches for vim (with Unite) and emacs (with Helm) to use this feature.
Obviously, this PR must first be accepted before I create new PRs for the corresponding projects.

### Vim

![omnisharp](https://cloud.githubusercontent.com/assets/536407/8394350/caaac0e6-1d2a-11e5-867d-9c46825dd16d.gif)

### Emacs

![omnisharp_emacs](https://cloud.githubusercontent.com/assets/536407/8394351/caaf8356-1d2a-11e5-8358-2123a64378b1.gif)





