### PR TITLE
Remove LowerCaseDriveLetter function

### DIFF
--- a/OmniSharp.Tests/FakeSolution.cs
+++ b/OmniSharp.Tests/FakeSolution.cs
@@ -32,13 +32,13 @@ namespace OmniSharp.Tests
         {
             return (from project in Projects
                     from file in project.Files
-                    where file.FileName.LowerCaseDriveLetter() == filename
+                    where file.FileName == filename
                     select file).FirstOrDefault();
         }
 
         public IProject ProjectContainingFile(string filename)
         {
-            return Projects.FirstOrDefault(p => p.Files.Any(f => f.FileName.LowerCaseDriveLetter().Equals(filename.LowerCaseDriveLetter(), StringComparison.InvariantCultureIgnoreCase)));
+            return Projects.FirstOrDefault(p => p.Files.Any(f => f.FileName.Equals(filename, StringComparison.InvariantCultureIgnoreCase)));
         }
 
         public void Reload()

--- a/OmniSharp.Tests/Solution/SolutionTest.cs
+++ b/OmniSharp.Tests/Solution/SolutionTest.cs
@@ -60,7 +60,7 @@ namespace OmniSharp.Tests
         [Test]
         public void Should_put_unknown_file_near_to_close_project_file()
         {
-            _solution.ProjectContainingFile((Environment.CurrentDirectory + "/Solution/minimal/minimal/test.cs").LowerCaseDriveLetter())
+            _solution.ProjectContainingFile((Environment.CurrentDirectory + "/Solution/minimal/minimal/test.cs"))
                 .Title.ShouldEqual("minimal");
         }
 

--- a/OmniSharp/Common/Request.cs
+++ b/OmniSharp/Common/Request.cs
@@ -13,7 +13,7 @@ namespace OmniSharp.Common
             get { return _fileName; }
             set
             {
-                _fileName = value.ApplyPathReplacementsForServer().LowerCaseDriveLetter();
+                _fileName = value.ApplyPathReplacementsForServer();
             }
         }
     }

--- a/OmniSharp/FindUsages/FindUsagesHandler.cs
+++ b/OmniSharp/FindUsages/FindUsagesHandler.cs
@@ -35,7 +35,7 @@ namespace OmniSharp.FindUsages
         {
             var result = FindUsageNodes(request)
                             .Distinct(new NodeComparer())
-                            .OrderBy(n => n.GetRegion().FileName.LowerCaseDriveLetter())
+                            .OrderBy(n => n.GetRegion().FileName)
                             .ThenBy(n => n.StartLocation.Line)
                             .ThenBy(n => n.StartLocation.Column);
                             
@@ -45,7 +45,7 @@ namespace OmniSharp.FindUsages
                 var usages = result.Select(node => new QuickFix
                 {
                     FileName = node.GetRegion().FileName,
-                    Text = node.Preview(_solution.GetFile(node.GetRegion().FileName.LowerCaseDriveLetter()), request.MaxWidth).Replace("'", "''"),
+                    Text = node.Preview(_solution.GetFile(node.GetRegion().FileName), request.MaxWidth).Replace("'", "''"),
                     Line = node.StartLocation.Line,
                     Column = node.StartLocation.Column,
                 });
@@ -120,7 +120,7 @@ namespace OmniSharp.FindUsages
 
                     Parallel.ForEach(interesting.Distinct(), file =>
                         {
-                            string text = _solution.GetFile(file.FileName.LowerCaseDriveLetter()).Content.Text;
+                            string text = _solution.GetFile(file.FileName).Content.Text;
                             SyntaxTree unit ;
                             if(project.CompilerSettings!=null){
                             	unit = new CSharpParser(project.CompilerSettings).Parse(text, file.FileName);

--- a/OmniSharp/GotoDefinition/GotoDefinitionHandler.cs
+++ b/OmniSharp/GotoDefinition/GotoDefinitionHandler.cs
@@ -27,7 +27,7 @@ namespace OmniSharp.GotoDefinition
             if (resolveResult != null)
             {
                 var region = resolveResult.GetDefinitionRegion();
-                response.FileName = region.FileName == null ? null : region.FileName.LowerCaseDriveLetter().ApplyPathReplacementsForClient();
+                response.FileName = region.FileName == null ? null : region.FileName.ApplyPathReplacementsForClient();
                 response.Line = region.BeginLine;
                 response.Column = region.BeginColumn;
             }

--- a/OmniSharp/ProjectManipulation/AddReference/AddFileReferenceProcessor.cs
+++ b/OmniSharp/ProjectManipulation/AddReference/AddFileReferenceProcessor.cs
@@ -36,7 +36,7 @@ namespace OmniSharp.ProjectManipulation.AddReference
                     projectXml.Element(MsBuildNameSpace + "Project").Add(projectItemGroup);
                 }
 
-                project.AddReference(reference.LowerCaseDriveLetter());
+                project.AddReference(reference);
                 project.Save(projectXml);
 
                 response.Message = string.Format("Reference to {0} added successfully", referenceName);

--- a/OmniSharp/Rename/RenameHandler.cs
+++ b/OmniSharp/Rename/RenameHandler.cs
@@ -40,7 +40,7 @@ namespace OmniSharp.Rename
             var modfiedFiles = new List<ModifiedFileResponse>();
             response.Changes = modfiedFiles;
 
-            foreach (IGrouping<string, AstNode> groupedNodes in nodes.GroupBy(n => n.GetRegion().FileName.LowerCaseDriveLetter()))
+            foreach (IGrouping<string, AstNode> groupedNodes in nodes.GroupBy(n => n.GetRegion().FileName))
             {
                 string fileName = groupedNodes.Key;
                 OmniSharpRefactoringContext context;

--- a/OmniSharp/Solution/CSharpSolution.cs
+++ b/OmniSharp/Solution/CSharpSolution.cs
@@ -81,7 +81,7 @@ namespace OmniSharp.Solution
                 {
                     string typeGuid = match.Groups["TypeGuid"].Value;
                     string title = match.Groups["Title"].Value;
-                    string location = Path.Combine(directory, match.Groups["Location"].Value).LowerCaseDriveLetter();
+                    string location = Path.Combine(directory, match.Groups["Location"].Value);
                     string guid = match.Groups["Guid"].Value;
 
                     switch (typeGuid.ToUpperInvariant())

--- a/OmniSharp/Solution/StringExtensions.cs
+++ b/OmniSharp/Solution/StringExtensions.cs
@@ -18,11 +18,6 @@ namespace OmniSharp.Solution
             return Regex.Replace(stringToTrim, @"\s+", " ");
         }
 
-        public static string LowerCaseDriveLetter(this string path)
-        {
-        	return path.Replace(@"C:\", @"c:\").Replace(@"D:\", @"d:\");
-        }
-
 		public static string ForceWindowsPathSeparator(this string path)
 		{
 			return path.Replace ('/', '\\');


### PR DESCRIPTION
This PR removes the use of the `LowerCaseDriveLetter` function. There are several issues with it:
  - its purpose is to fix an [issue with Vim](https://github.com/OmniSharp/omnisharp-server/blob/947b9640d9978843d6e04e64cd3f24ac28abf7d4/OmniSharp/Solution/StringExtensions.cs). Ideally, client-specific issue should be fixed in the client, not in the server ;
  -  it forces clients and tests framework to apply the same hack when interacting with the server. See this [commit](https://github.com/micbou/ycmd/commit/97c1cd8092c1e80cd03d40848711a5b305e39f95) as an example ;
  - it seems unnecessary. All tests pass on Windows without it.
  - it only lowers the `C` and `D` drive letters. What if another letter is used?

