### PR TITLE
Added support for formatting that obeys `tabsize` and `tabstospaces`

### DIFF
--- a/OmniSharp.Tests/CodeFormat/CodeFormatTest.cs
+++ b/OmniSharp.Tests/CodeFormat/CodeFormatTest.cs
@@ -22,7 +22,27 @@ namespace OmniSharp.Tests.CodeFormat
            
             var handler = new CodeFormatHandler(new OmniSharpConfiguration());
             var buffer = handler.Format(new CodeFormatRequest {Buffer = code}).Buffer;
-			buffer.Replace("\r\n", "\n").ShouldEqual(expected);
+            buffer.Replace("\r\n", "\n").ShouldEqual(expected);
+        }
+
+        [Test]
+        public void Obeys_formatting_options()
+        {
+            string code =
+@"public class Test {
+public void ExampleMethod()
+{
+}
+}";
+
+            var handler = new CodeFormatHandler(new OmniSharpConfiguration());
+            var buffer = handler.Format(new CodeFormatRequest
+            {
+                Buffer = code,
+                TabSize = 4,
+                TabsToSpaces = false
+            }).Buffer;
+            buffer.ShouldContain('\t');
         }
     }
 }

--- a/OmniSharp/CodeFormat/CodeFormatHandler.cs
+++ b/OmniSharp/CodeFormat/CodeFormatHandler.cs
@@ -15,6 +15,10 @@ namespace OmniSharp.CodeFormat
         {
             var options = _config.TextEditorOptions;
             var policy = _config.CSharpFormattingOptions;
+
+            options.TabsToSpaces = request.TabsToSpaces;
+            options.TabSize = request.TabSize;
+
             var formatter = new CSharpFormatter(policy, options);
             formatter.FormattingMode = FormattingMode.Intrusive;
             var output = formatter.Format(request.Buffer);

--- a/OmniSharp/CodeFormat/CodeFormatRequest.cs
+++ b/OmniSharp/CodeFormat/CodeFormatRequest.cs
@@ -11,5 +11,9 @@ namespace OmniSharp.CodeFormat
             get { return _expandTab; }
             set { _expandTab = value; }
         }
+
+        public bool TabsToSpaces { get; set; } = true;
+
+        public int TabSize { get; set; } = 4;
     }
 }


### PR DESCRIPTION
Would be nice to have this, so I can fork omnisharp-vscode and add support so it doesn't cause issues like https://github.com/OmniSharp/omnisharp-vscode/issues/93