### PR TITLE
Add OS X Unity3d mono Paths

### DIFF
--- a/OmniSharp/Solution/AssemblySearch.cs
+++ b/OmniSharp/Solution/AssemblySearch.cs
@@ -51,7 +51,15 @@ namespace OmniSharp.Solution
             @"/Library/Frameworks/Mono.framework/Libraries/mono/4.0",
             @"/Library/Frameworks/Mono.framework/Libraries/mono/3.5",
             @"/Library/Frameworks/Mono.framework/Libraries/mono/2.0",
-            @"~/.kpm/packages"
+            @"~/.kpm/packages",
+
+
+            //OS X Unity3d mono Paths
+            @"/Applications/Unity/MonoDevelop.app/Contents/Frameworks/Mono.framework/Versions/Current/lib/mono/4.5",
+            @"/Applications/Unity/MonoDevelop.app/Contents/Frameworks/Mono.framework/Versions/Current/lib/mono/4.0",
+            @"/Applications/Unity/MonoDevelop.app/Contents/Frameworks/Mono.framework/Versions/Current/lib/mono/3.5",
+            @"/Applications/Unity/MonoDevelop.app/Contents/Frameworks/Mono.framework/Versions/Current/lib/mono/2.0"
+
         };
     }
 }


### PR DESCRIPTION
I just install unity3d, and it contains mono already . so it is no need to install mono again. but in the AssemblySearch.cs , 
the search path is not include `/Applications/Unity/MonoDevelop.app/Contents/Frameworks/Mono.framework/Versions/Current/lib/mono/*`

so I add it . because unity3d is widely used by peoples.

